### PR TITLE
Fix sidebar git url

### DIFF
--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -8,6 +8,6 @@
 - [Frequently Asked Questions](faq)
 - **Links**
 - [![Discord](https://icongr.am/simple/discord.svg?colored&size=16)Discord](https://discord.gg/nYcQFEpXfU)
-- [![GitHub](https://icongr.am/simple/github.svg?color=808080&size=16)GitHub](https://github.com/legoandmars/LethalCompanyModdingWiki)
+- [![GitHub](https://icongr.am/simple/github.svg?color=808080&size=16)GitHub](https://github.com/LethalCompany/ModdingWiki)
 <!-- - [![Translate](https://icongr.am/material/translate.svg?color=808080&size=16)Translate](https://crowdin.com/project/trombone-champ-modding-wiki) -->
 - [About](about)


### PR DESCRIPTION
Was using the old, pre-org url. Is now fixed.