### PR TITLE
Indexing fixes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,9 @@ export default defineConfig({
     return head
   },
   cleanUrls: true,
+  sitemap: {
+    hostname: 'https://lethal.wiki/'
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     search: {
@@ -27,7 +30,6 @@ export default defineConfig({
       { text: 'Beginners Guide', link: '/beginners-guide.md' },
       { text: 'Discord', link: 'https://discord.gg/nYcQFEpXfU' }
     ],
-
     sidebar: {
       '/': [
         {
@@ -70,6 +72,7 @@ export default defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/LethalCompany/ModdingWiki' }
     ],
+    externalLinkIcon: true,
     editLink: {
       pattern: 'https://github.com/LethalCompany/ModdingWiki/edit/main/docs/:path',
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -72,7 +72,6 @@ export default defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/LethalCompany/ModdingWiki' }
     ],
-    externalLinkIcon: true,
     editLink: {
       pattern: 'https://github.com/LethalCompany/ModdingWiki/edit/main/docs/:path',
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
 
     return head
   },
+  cleanUrls: true,
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     search: {

--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -19,7 +19,7 @@ If you're on Linux or Steam Deck, you'll want the [linux installation guide](./i
 
 ## Creating mods
 
-If you're interested in trying to create your own mod for Lethal Company, you can find some basic modding guides in the [Modding section.](./modding/initial-setup.md).
+If you're interested in trying to create your own mod for Lethal Company, you can find some basic modding guides in the [Modding section](./modding/initial-setup.md).
 
 Right now this guide only goes over writing mods with code, although guides for Assets (cosmetics, suits, etc) will likely be added in the future.
 


### PR DESCRIPTION
This PR adds a couple things that should make indexing better:
- use "clean" urls (eg; `https://lethal.wiki/beginners-guide` instead of `https://lethal.wiki/beginners-guide.html`)
- use the automatic sitemap generation from vitepress
- fix a typo that was showing up on google