### PR TITLE
Add "Modding APIs" section

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,6 +54,12 @@ export default defineConfig({
               ]
             },
             { 
+              text: 'Modding APIs', 
+              items: [
+                { text: 'Modding APIs Overview', link: '/apis/modding-apis' },
+              ]
+            },
+            { 
               text: 'Advanced Modding Topics', 
               items: [
                 { text: 'Custom Networking', link: '/advanced-modding/networking' }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,15 +54,15 @@ export default defineConfig({
               ]
             },
             { 
-              text: 'Modding APIs', 
-              items: [
-                { text: 'Modding APIs Overview', link: '/apis/modding-apis' },
-              ]
-            },
-            { 
               text: 'Advanced Modding Topics', 
               items: [
                 { text: 'Custom Networking', link: '/advanced-modding/networking' }
+              ]
+            },
+            { 
+              text: 'Modding APIs', 
+              items: [
+                { text: 'Modding APIs Overview', link: '/apis/modding-apis' },
               ]
             },
             { 

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -9,18 +9,24 @@ description: A list of specific modding APIs for Lethal Company and how to use t
 There are two types of API that will be covered in this overview:
 
 - Non-code API: An API or custom content mod that can be used without writing any code. Good if you want something simple that even non-programmers can create something with.
-- Code API: A user-created modding API that can be intergrated into your C# mod for Lethal Company.
+- Code API: A user-created modding API that can be intergrated into your C# Lethal Company mod.
 
 There may be multiple APIs for a single concept, each with their own pros and cons.
-
 ## Non-code APIs
-### Sound Modding
-- CustomSounds by X
-
-### Custom Suits
-- MoreSuits by X
 
 ### Cosmetics
-- MoreCompany by X
+- [MoreCompany by notnotnotswipez](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) has a feature that adds custom cosmetics (hats, badges, etc). You can learn how to create your own through the official [Cosmetic Creation Guide](https://github.com/notnotnotswipez/MoreCompany/wiki/Cosmetic-Creation).
+
+
+### Custom Suits
+- [MoreSuits by x753](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) allows you to create your own custom ingame suits using only a .png file. [The README](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) has a basic section on how to format your suit mod for upload.
+
+### Sound Modding
+- [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [This guide by milleroski](https://github.com/milleroski/Lethal-Company-Sound-Modding-Guide) covers the process of creating your own Custom Sound using CustomSounds.
 
 ## Code APIs
+
+### Sound Modding 
+- [LCSoundTool by no00ob](https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/wiki/828-audio-logging/) allows you to replace sounds at runtime. [The mod's Thunderstore wiki](https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/wiki/) covers how to use it.
+
+### Extending Ingame Terminal

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -1,7 +1,7 @@
 ---
 prev: false
 next: false
-description: A list of specific modding APIs for Lethal Company and how to use them.
+description: A list of specific modding APIs for Lethal Company, and documentation on how to use them.
 ---
 
 # Modding APIs Overview
@@ -12,21 +12,53 @@ There are two types of API that will be covered in this overview:
 - Code API: A user-created modding API that can be intergrated into your C# Lethal Company mod.
 
 There may be multiple APIs for a single concept, each with their own pros and cons.
+
+APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
+
 ## Non-code APIs
 
 ### Cosmetics
 - [MoreCompany by notnotnotswipez](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) has a feature that adds custom cosmetics (hats, badges, etc). You can learn how to create your own through the official [Cosmetic Creation Guide](https://github.com/notnotnotswipez/MoreCompany/wiki/Cosmetic-Creation).
 
-
 ### Custom Suits
 - [MoreSuits by x753](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) allows you to create your own custom ingame suits using only a .png file. [The README](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) has a basic section on how to format your suit mod for upload.
 
-### Sound Modding
+### Items & Scrap
+- [LethalExpansion by HolographicWings](https://thunderstore.io/c/lethal-company/p/HolographicWings/LethalExpansion/) allows you to create your own scrap using a custom Unity SDK. [The SDK's README](https://github.com/HolographicWings/LethalSDK-Unity-Project) has a basic usage tutorial.
+
+### Posters
+- [LethalPosters by femboytv](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) allows you to create your own custom posters that appear in the ship. [The README](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) has a basic section on how to format your poster for upload.
+
+### Sound Replacement
 - [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [This guide by milleroski](https://github.com/milleroski/Lethal-Company-Sound-Modding-Guide) covers the process of creating your own Custom Sound using CustomSounds.
+<!-- Add a gold star when #28 is merged -->
 
 ## Code APIs
 
-### Sound Modding 
+### Enemies
+- [LethalLib by Evaisa](https://thunderstore.io/c/lethal-company/p/Evaisa/LethalLib/) allows you to add new enemies, although the process is fairly involved and not currently well documented.
+
+### Input
+- [InputUtils by Rune580](https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/) allows you to easily initialize input/keybinds with ingame rebinding. [The README](https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/) has a developer quickstart.
+
+### Items & Scrap
+- [LethalLib by Evaisa](https://thunderstore.io/c/lethal-company/p/Evaisa/LethalLib/) allows you to add new Scrap & Shop Items.
+
+### Model Replacement
+- [ModelReplacementAPI by BunyaPineTree](https://thunderstore.io/c/lethal-company/p/BunyaPineTree/ModelReplacementAPI/) allows you to create your own custom player models, and swaps them out at runtime. [The mod's official wiki](https://github.com/BunyaPineTree/LethalCompany_ModelReplacementAPI/wiki) explains how to set up a player model.
+
+### Sound Replacement 
 - [LCSoundTool by no00ob](https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/wiki/828-audio-logging/) allows you to replace sounds at runtime. [The mod's Thunderstore wiki](https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/wiki/) covers how to use it.
 
-### Extending Ingame Terminal
+### Terminal
+- [TerminalApi by NotAtomicBomb](https://github.com/NotAtomicBomb/TerminalApi) adds a nice and easy way to add and modify terminal keywords. [The mod's GitHub README](https://github.com/NotAtomicBomb/TerminalApi) has documentation and an example plugin to reference.
+
+
+## Adding APIs to the wiki
+
+If you're an API developer and want to get your API added to this list, feel free to make a [pull request](https://github.com/LethalCompany/ModdingWiki), assuming your API meets the following criteria:
+
+- Open source
+- Fairly well documented - even better if you write a wiki article*
+<!-- I would love a way to do a superscript citation here but I don't know if you can by default? -->
+\* Some exceptions may be made if it's an especially groundbreaking API, or it's the only existing solution.

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -1,0 +1,26 @@
+---
+prev: false
+next: false
+description: A list of specific modding APIs for Lethal Company and how to use them.
+---
+
+# Modding APIs Overview
+
+There are two types of API that will be covered in this overview:
+
+- Non-code API: An API or custom content mod that can be used without writing any code. Good if you want something simple that even non-programmers can create something with.
+- Code API: A user-created modding API that can be intergrated into your C# mod for Lethal Company.
+
+There may be multiple APIs for a single concept, each with their own pros and cons.
+
+## Non-code APIs
+### Sound Modding
+- CustomSounds by X
+
+### Custom Suits
+- MoreSuits by X
+
+### Cosmetics
+- MoreCompany by X
+
+## Code APIs

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -59,6 +59,6 @@ APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
 If you're an API developer and want to get your API added to this list, feel free to make a [pull request](https://github.com/LethalCompany/ModdingWiki), assuming your API meets the following criteria:
 
 - Open source
-- Fairly well documented - even better if you write a wiki article*
-<!-- I would love a way to do a superscript citation here but I don't know if you can by default? -->
-\* Some exceptions may be made if it's an especially groundbreaking API, or it's the only existing solution.
+- Fairly well documented - even better if you write a wiki article<sup>1</sup>
+
+<sup>1</sup>: Some exceptions may be made if it's an especially groundbreaking API, or it's the only existing solution.

--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -21,9 +21,15 @@ Want a quick, easy way to install the same mods as your friends? Check out the [
 
 ## Creating mods
 
+::: tip
+If you can't code and want to create a mod that does one common, simple thing (such as adding a suit or sound replacement) make sure to check the [non-code Modding APIs](/apis/modding-apis#non-code-apis) section!
+
+Many common usecases already have APIs that allow you to easily add content without using any code.
+:::
+
 If you're interested in trying to create your own mod for Lethal Company, you can find some basic modding guides in the [Modding section](./modding/initial-setup.md).
 
-Right now this guide only goes over writing mods with code, although guides for Assets (cosmetics, suits, etc) will likely be added in the future.
+Once you're set up, make sure to check the [Modding APIs](/apis/modding-apis) section to see if there's any libraries that would make creating your mod easier.
 
 ## Support
 ::: tip

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,7 @@ hero:
 
   <HomeGroup title="Creating Mods">
     <HomeItem name="Initial modding setup" href="./modding/initial-setup.html" />
-    <HomeItem name="Starting a mod" href="./modding/starting-a-mod.html" />
-    <HomeItem name="Open-source and ethics" href="./modding/open-source-and-ethics.html" />
+    <HomeItem name="Modding APIs overview" href="./apis/modding-apis" />
     <HomeItem name="Publishing your mod" href="./modding/publishing-your-mod.html" />
   </HomeGroup>
 

--- a/docs/modding/initial-setup.md
+++ b/docs/modding/initial-setup.md
@@ -6,7 +6,7 @@ description: Learn how to install all the necessary prerequisites to get started
 # Initial Setup
 
 ::: tip
-If you can't code and want to create a mod that does one specific, simple thing (such as adding a suit or sound replacement) make sure to check the [non-code Modding APIs](/apis/modding-apis#non-code-apis) section!
+If you can't code and want to create a mod that does one common, simple thing (such as adding a suit or sound replacement) make sure to check the [non-code Modding APIs](/apis/modding-apis#non-code-apis) section!
 
 Many common usecases already have APIs that allow you to easily add content without using any code.
 :::

--- a/docs/modding/initial-setup.md
+++ b/docs/modding/initial-setup.md
@@ -5,6 +5,16 @@ description: Learn how to install all the necessary prerequisites to get started
 
 # Initial Setup
 
+::: tip
+If you can't code and want to create a mod that does one specific, simple thing (such as adding a suit or sound replacement) make sure to check the [non-code Modding APIs](/apis/modding-apis#non-code-apis) section!
+
+Many common usecases already have APIs that allow you to easily add content without using any code.
+:::
+
+This section of the wiki will cover how to get set up for development.
+
+Once you're set up, make sure to check the [Modding APIs](/apis/modding-apis) section to see if there's any libraries that would make creating your mod easier.
+
 ## Setting up your development environment
 
 Before you can start modding, you'll need some tools to actually create mods. Luckily, all of these are **available for free**. 


### PR DESCRIPTION
The wiki needs a definitive source of user-created APIs for common usecases, as discussed in #28 

This PR adds a modding API section with:
- A section for non-code APIs so non-programmers can have a section to check for simple swaps (like audio replacement, custom suits, etc)
- A section for code APIs so modders can have an easy overview

I think going forward, at least for now, the sections should be:
- Initial setup (Max's guide on how to get everything initialized)
- Modding APIs (for user-created APIs, such as customsounds)
- Advanced Modding (for specific topics like Networking and creating Configs. the section may need a rename)

Here's an example of what I think the Modding APIs section could look like once we start getting some guides (like #28)
![image](https://github.com/LethalCompany/ModdingWiki/assets/34404266/6865251b-5933-4cfa-88cf-b00e84eefefb)
