### PR TITLE
Audio modding formatting tweaks I forgot about

### DIFF
--- a/docs/apis/customsounds.md
+++ b/docs/apis/customsounds.md
@@ -1,3 +1,9 @@
+---
+prev: false
+next: false
+description: A guide to replacing sounds in Lethal Company with custom versions using the CustomSounds mod. 
+---
+
 # A guide to Lethal Company audio modding (using CustomSounds)
 
 ::: warning 
@@ -7,33 +13,43 @@ This is not a tutorial on how to replace audio with BepInEx using Harmony Patchi
 ## Installing the mods
 You need to install the following mods to be able to add custom sounds:
 
-- BepinExPack by BepInEx (<https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/>)
+- [BepinExPack by BepInEx](https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/)
 
-- LCSoundTool by no00ob (<https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/>)
+- [LCSoundTool by no00ob](https://thunderstore.io/c/lethal-company/p/no00ob/LCSoundTool/)
 
-- CustomSounds by Clementinise (<https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/>)
+- [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/)
 
 If you're using r2modman or the Thunderstore manager, your basic setup should look like this:
+
 ![Image of r2modman setup](/images/customsounds/r2modman_setup.png)
 
 ## Finding the audio files 
 If you want to replace an audio file, you need to know which sound you're actually replacing. For the sake of the guide, I'm going to try and find the audio files for the "Icecream Truck" music whenever the delivery ship lands, but you can apply this process to any sound you'd like to replace.
 
 ### Extracting the audio files
-To find the sound file you want to replace, I personally recommend extracting all the audio files from the game so you have easy access to them, which makes finding them a lot easier. You can do this by using a program called AssetRipper (<https://github.com/AssetRipper/AssetRipper/releases>). Make sure to use the latest version (NOT the pre-release one).
+To find the sound file you want to replace, I personally recommend extracting all the audio files from the game so you have easy access to them, which makes finding them a lot easier. 
 
-First, open up AssetRipper and select the Audio Export Format as "Covert to WAV", as the audio mods we're using can only handle .wav files. Afterwards, on the top toolbar go to File > Open Folder, and select "Lethal Company_Data", which you can find in the directory where Lethal Company is installed (if you don't know where your game is installed, just go to Steam, right click on Lethal Company, and then go to Manage > Browse Local Files).
+You can do this by using a program called [AssetRipper](https://github.com/AssetRipper/AssetRipper/releases). Make sure to use the latest version (NOT the pre-release one).
+
+First, open up AssetRipper and select the Audio Export Format as "Convert to WAV", as the audio mods we're using can only handle .wav files. 
+
+Afterwards, on the top toolbar go to `File > Open Folder`, and select "Lethal Company_Data", which you can find in the directory where Lethal Company is installed (if you don't know where your game is installed, just go to Steam, right click on Lethal Company, and then go to `Manage > Browse Local Files`).
 
 If everything worked correctly, you should be seeing this window:
+
 ![Image of Assetripper](/images/customsounds/AssetRipper.png)
 
-Now, to extract ALL the audio files from the game, you need to find an AudioClip file in one of the sharedassets folders. For example, if you click on the arrow next to sharedassets0 and then the one next to AudioClip you should be able to see the files BootUp, ButtonPress1 and HoverButton1. Now, click on any one of these files so that it's selected, and at the top click on Export > Export All Files of Selected Type. Afterwards, select where you would like to save the audio files and click Select Folder. At the time of writing this guide, there should be exactly 769 audio files that you can export.
+Now, to extract ALL the audio files from the game, you need to find an AudioClip file in one of the sharedassets folders. 
 
-Afterwards, go to the directory you exported the audio files to, and go to Lethal Company\ExportedProject\Assets\AudioClip, and there, you should be able to see all the audio files that are currently in the game! Feel free to copy these files somewhere else or to delete the .meta files.
+For example, if you click on the arrow next to `sharedassets0` and then the one next to AudioClip you should be able to see the files `BootUp`, `ButtonPress1` and `HoverButton1`. Now, click on any one of these files so that it's selected, and at the top click on `Export > Export All Files of Selected Type`. 
 
-You can usually find the files just by looking at the audio names, they have pretty logical names. For example, the ship "ice cream truck music" is literally called "IcecreamTruckV2" and "IcecreamTruckFar". 
+Afterwards, select where you would like to save the audio files and click Select Folder. At the time of writing this guide, there should be exactly 769 audio files that you can export.
 
-However, if you REALLY can't find the sound file you're looking for, then **Step 2.2** is for you. Otherwise, you can go directly to **Step 3**.
+Afterwards, go to the directory you exported the audio files to, and go to `Lethal Company\ExportedProject\Assets\AudioClip`, and there, you should be able to see all the audio files that are currently in the game! Feel free to copy these files somewhere else or to delete the `.meta` files.
+
+You can usually find the files just by looking at the audio names, they have pretty logical names. For example, the ship "ice cream truck music" is literally called `"IcecreamTruckV2"` and `"IcecreamTruckFar"`. 
+
+However, if you REALLY can't find the sound file you're looking for, then [**Step 2.2**](#using-lcsoundtool) is for you. Otherwise, you can go directly to [**Step 3**](#replacing-the-audio-files).
 
 ### Using LCSoundTool
 
@@ -44,6 +60,7 @@ If you already have found the audio file you're looking for, you can skip direct
 If you can't find the sound you're replacing by just looking at the extracted audio files, then you can use method this to find out the exact name of the sound file.
 
 LCSoundTool has a logging function which can be activated / deactivated by pressing F5 when in the game, and it prints the current sound being played to the BepinEx console. For this to actually show up in the console, you need to edit the BepInEx.cfg file, which you can access by going to BepInEx/config/BepInEx.cfg, or if you're using r2modman / Thunderstore, by going into Config Editor and BePinEx.cfg as shown in this image:
+
 ![Image of config in r2modman](/images/customsounds/r2modman_config.png)
 
 In particular, you need to change 4 settings to the following parameters:
@@ -62,24 +79,25 @@ Now when you boot up the game you should see the following message whenever you 
 If you want to find out the sounds of enemies, I recommend downloading the mod "**GameMaster**" as it allows you to spawn enemies and give yourself god mode so you don't die while you look at the console, and a bunch of other options that make this process easier.
 
 Anyways, for the "Ice cream truck" music, I ordered an item through the terminal and spawned into a map, and once it arrives you can clearly see which sounds are responsible for playing the music:
+
 ![Image of BepInEx Console](/images/customsounds/BepInEx_console.png)
 
-So now we know that we need to replace the sound files IcecreamTruckFar and IcecreamTruckV2 to make it play custom music! You can repeat this process for (almost) all sounds, so if you want to know what sounds the Jester enemy makes, then you spawn in a Jester enemy and wait until it plays the sound effect you want to replace.
+So now we know that we need to replace the sound files `IcecreamTruckFar` and `IcecreamTruckV2` to make it play custom music! You can repeat this process for (almost) all sounds, so if you want to know what sounds the Jester enemy makes, then you spawn in a Jester enemy and wait until it plays the sound effect you want to replace.
 
 ## Replacing the audio files
-So, now we know that the files we're looking for are IcecreamTruckFar and IcecreamTruckV2. How do you replace them?
+So, now we know that the files we're looking for are `IcecreamTruckFar` and `IcecreamTruckV2`. How do you replace them?
 
-First, you need to rename whatever audio file you're going to use to replace the original one, and (if it isn't already) change the audio format to .wav. So if you have a file called IcecreamMusic.mp3, then you need to rename it to IcecreamTruckV2 and convert it to .wav.
+First, you need to rename whatever audio file you're going to use to replace the original one, and (if it isn't already) change the audio format to `.wav`. So if you have a file called `IcecreamMusic.mp3`, then you need to rename it to `IcecreamTruckV2` and convert it to `.wav`.
 
 Once you're done with that, you need to place the audio files in the folder where CustomSounds is installed.
 
 For the **manual installers**:
 
- Go to BepInEx\plugins\CustomSounds and place the files either directly in there or make another folder inside of CustomSounds and put them there.
+ Go to `BepInEx\plugins\CustomSounds` and place the files either directly in there or make another folder inside of CustomSounds and put them there.
 
 For **r2modman \ Thunderstore** users:
 
-Go to settings>Browse profile folder, and then go into BepInEx\plugins\Clementinise-CustomSounds\CustomSounds and either place the audio files directly there or make another folder inside of CustomSounds and put them there.
+Go to settings>Browse profile folder, and then go into `BepInEx\plugins\Clementinise-CustomSounds\CustomSounds` and either place the audio files directly there or make another folder inside of CustomSounds and put them there.
 
 **Note:** r2modman WILL delete your custom sound files each time you update CustomSounds, so I would recommend to keep your replacement sounds in another folder so you can quickly swap them back in the case an update comes out.
 
@@ -93,20 +111,23 @@ Additionally, you can now add short descriptions to sounds that show up in the t
 
 ## Testing the replacement
 If you did everything correctly, you should see the files loading in the BepInEx console. Alternatively, you can just go into your ship and type "customsounds help" in your terminal to see all the available commands. If your replacement sounds have loaded correctly, then you should be able to see them if you type in "customsounds list" like this:
+
 ![Image of terminal using the CustomSounds command](/images/customsounds/CustomSounds_console.png)
 
 Here's a little fun demo of how this particular setup looks like:
+
 [![Watch the video](/images/customsounds/Youtube_thumbnail.png)](https://youtu.be/mk8O8qFcMlk)
 
 ## Sharing custom sounds with friends
 
 ### File sharing
 
-This one is by far the most obvious and simple method, you just put the audio files into a .zip file, upload it somewhere, tell your friends to download it and put it into the CustomSounds folder, and that's it.
+This one is by far the most obvious and simple method, you just put the audio files into a `.zip` file, upload it somewhere, tell your friends to download it and put it into the CustomSounds folder, and that's it.
 
 ### Customsounds syncing feature
 
 The second one uses a new experimental feature of CustomSounds, which allows your friends to synchronize their custom sounds with yours. As before, you can type in "customsounds help" to see all the available commands. The command of interest to you is the "customsounds sync" command. Once you type in this command, everyone in your lobby should get this prompt:
+
 ![Image of Sync request](/images/customsounds/Sync_request_client.png)
 
 Once the clients press F8, the host will send all the custom sounds to all clients, and they will be immediately loaded by the clients once the download is complete. In the case that someone doesn't want to use your custom sounds, they can use "customsounds revert" to use the original game files instead.
@@ -131,6 +152,6 @@ For the rest, check out the section on how to [publish your mod](/modding/publis
 
 ## Credits
 
-If you have any questions then feel free to ping me over on the [Lethal Company Discord](https://discord.gg/lethal-company), or just DM me on Discord (nickname: futuresavior). Please do NOT send me friend requests on Discord, just DM me directly, and don't forget to have fun \:)
+If you have any questions then feel free to ping me over on the [Lethal Company Discord](https://discord.gg/lethal-company), or just DM me on Discord (nickname: `futuresavior`). Please do NOT send me friend requests on Discord, just DM me directly, and don't forget to have fun \:)
 
 Thank you to Clementinise for creating CustomSounds and proof-reading my guide, and to no00ob for creating LCSoundTool, both of your mods are amazing and appreciated \<3

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -30,7 +30,7 @@ APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
 - [LethalPosters by femboytv](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) allows you to create your own custom posters that appear in the ship. [The README](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) has a basic section on how to format your poster for upload.
 
 ### Sound Replacement
-- [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [This guide by milleroski](https://github.com/milleroski/Lethal-Company-Sound-Modding-Guide) covers the process of creating your own Custom Sound using CustomSounds.
+- ⭐ [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [The wiki page on CustomSounds](/apis/customsounds) covers the process of creating your own Custom Sound.
 <!-- Add a gold star when #28 is merged -->
 
 ## Code APIs

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -30,8 +30,7 @@ APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
 - [LethalPosters by femboytv](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) allows you to create your own custom posters that appear in the ship. [The README](https://thunderstore.io/c/lethal-company/p/femboytv/LethalPosters/) has a basic section on how to format your poster for upload.
 
 ### Sound Replacement
-- ⭐ [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [The wiki page on CustomSounds](/apis/customsounds) covers the process of creating your own Custom Sound.
-<!-- Add a gold star when #28 is merged -->
+- ⭐ [CustomSounds by Clementinise](https://thunderstore.io/c/lethal-company/p/Clementinise/CustomSounds/) allows you to replace ingame sounds using your own .wav file. [The wiki page on CustomSounds](/apis/customsounds) covers the process of creating of swapping out sounds.
 
 ## Code APIs
 


### PR DESCRIPTION
A few minor formatting tweaks for @milleroski's audio modding page

- Directly link it in `modding-apis.md` and add a gold star
- Add a description to the page for embeds, and remove the buttons at the bottom
- Convert links to use markdown links instead of posting the full link
- Put backticks around file extensions and paths
- Put whitespace before images so spacing looks a bit better
- Break up a couple large paragraphs