### PR TITLE
Simplified Header Anchors

### DIFF
--- a/docs/advanced-modding/networking.md
+++ b/docs/advanced-modding/networking.md
@@ -18,7 +18,7 @@ This is not a tutorial on how to use Unity's [Netcode for GameObjects](https://d
 
 This tutorial requires using [@EvaisaDev](https://github.com/EvaisaDev/)'s [UnityNetcodeWeaver](https://github.com/EvaisaDev/UnityNetcodeWeaver) (Thank you very much Evaisa!). This tutorial will only go into the basics of using this tool; if you run into any issues, ask in the [NetcodePatcher Forum Post](https://discord.com/channels/1169792572382773318/1175504315029389343) on the [Unofficial Lethal Company Community Discord](https://discord.gg/nYcQFEpXfU).
 
-### Why use Unity Netcode Weaver?
+### Why use Unity Netcode Weaver? {#why-netcode-weaver}
 
 Unity Netcode Weaver replicates the IL Post Processing Unity performs when compiling code utilizing Netcode for GameObjects package. This turns the C# code before the post processing step:
 
@@ -141,7 +141,7 @@ public void EventServerRPC(/*parameters here*/)
 }
 ```
 
-### C# Events
+### C# Events {#csharp-events}
 
 Now, you may ask, what is `public static event Action<String> LevelEvent`? This uses C#'s event/delegate system to create a readable event. While it may look complex at first, it turns out to be quite simple! A script can subscribe to the event - which will be shown later - then, when the event is invoked, any specified method(s) will run.
 
@@ -156,7 +156,7 @@ if (LevelEvent != null)
 
 All this if statement checks is whether the event is not equal to null and calls the event if so. The event will be null *if there are no subscribers to the event.*
 
-### Preventing Duplication of Events and Instance
+### Preventing Duplication of Events and Instance {#preventing-duplication}
 
 Since we are using `static` when defining our C# event, an edge case can occur. What happens if the event is not unsubscribed from, and the player joins a new server? Any code that unknowingly subscribes to the event a second time will run twice! How do we make sure this does not occur? We set the C# event to equal null. The best time to do so is when the NetworkHandler gets spawned in:
 
@@ -287,7 +287,7 @@ public static void Init()
 }
 ```
 
-### Adding Asset as Network Prefab
+### Adding the Asset as a Network Prefab {#adding-network-prefab}
 
 Now that we have the prefab ready to be loaded, it's quite simple to give this to the NetworkManager as a prefab:
 
@@ -315,7 +315,7 @@ public static void Init()
 }
 ```
 
-### Spawning the GameObject During Runtime
+### Spawning the GameObject During Runtime {#spawning-the-gameobject}
 
 Now that the game knows what to load when we tell it to load the ExampleNetworkHandler, all we have left is to spawn it! To do so, we just must Instantiate the prefab, then spawn it:
 
@@ -425,7 +425,7 @@ When subscribing and unsubscribing to an event, make sure that <i>both</i> the h
 Hooking to a ClientRpc can cause errors with code running multiple times on the host instance. Avoid hooking to any ClientRpcs - and if you must, consider adding a debounce.
 :::
 
-## Using UnityNetcodeWeaver
+## Using Unity Netcode Weaver {#using-netcode-weaver}
 
 Now that we've finished the networking code, all that's left is to patch the compiled mod assembly with Unity Netcode Weaver/Patcher. Before we can do so, we need to prepare the mod for patching. 
 

--- a/docs/apis/customsounds.md
+++ b/docs/apis/customsounds.md
@@ -118,13 +118,13 @@ Here's a little fun demo of how this particular setup looks like:
 
 [![Watch the video](/images/customsounds/Youtube_thumbnail.png)](https://youtu.be/mk8O8qFcMlk)
 
-## Sharing custom sounds with friends
+## Sharing custom sounds with friends {#sharing-custom-sounds}
 
 ### File sharing
 
 This one is by far the most obvious and simple method, you just put the audio files into a `.zip` file, upload it somewhere, tell your friends to download it and put it into the CustomSounds folder, and that's it.
 
-### Customsounds syncing feature
+### CustomSounds syncing feature {#customsounds-syncing}
 
 The second one uses a new experimental feature of CustomSounds, which allows your friends to synchronize their custom sounds with yours. As before, you can type in "customsounds help" to see all the available commands. The command of interest to you is the "customsounds sync" command. Once you type in this command, everyone in your lobby should get this prompt:
 

--- a/docs/apis/modding-apis.md
+++ b/docs/apis/modding-apis.md
@@ -23,7 +23,7 @@ APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
 ### Custom Suits
 - [MoreSuits by x753](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) allows you to create your own custom ingame suits using only a .png file. [The README](https://thunderstore.io/c/lethal-company/p/x753/More_Suits/) has a basic section on how to format your suit mod for upload.
 
-### Items & Scrap
+### Items & Scrap {#asset-items-and-scrap}
 - [LethalExpansion by HolographicWings](https://thunderstore.io/c/lethal-company/p/HolographicWings/LethalExpansion/) allows you to create your own scrap using a custom Unity SDK. [The SDK's README](https://github.com/HolographicWings/LethalSDK-Unity-Project) has a basic usage tutorial.
 
 ### Posters
@@ -40,7 +40,7 @@ APIs marked with a `Gold Star ⭐` have a tutorial on this wiki.
 ### Input
 - [InputUtils by Rune580](https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/) allows you to easily initialize input/keybinds with ingame rebinding. [The README](https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/) has a developer quickstart.
 
-### Items & Scrap
+### Items & Scrap {#programming-items-and-scrap}
 - [LethalLib by Evaisa](https://thunderstore.io/c/lethal-company/p/Evaisa/LethalLib/) allows you to add new Scrap & Shop Items.
 
 ### Model Replacement

--- a/docs/extras/faq.md
+++ b/docs/extras/faq.md
@@ -7,18 +7,18 @@ description: Frequently asked Lethal Company modding questions.
 # Frequently Asked Questions
 ---
 
-## I Installed MoreCompany/BiggerLobby and it doesn't work.
+## I Installed MoreCompany/BiggerLobby and it doesn't work. {#morecompany-biggerlobby-not-working}
 
 Ensure that:
 - You only have EITHER MoreCompany or BiggerLobby installed. Trying to install both will break your game.
 - Everybody trying to join the server has the mod installed.
 - Everybody trying to join the server has the same mod version installed.
 
-## Do mods work with a pirated version of the game?
+## Do mods work with a pirated version of the game? {#pirating}
 
 Mods will only work on the latest Steam version of Lethal Company. Buy the game.
 
-## Does (X Mod) require everybody to have it installed?
+## Does (X Mod) require everybody to have it installed? {#require-all-to-install}
 
 It depends on the specific mod. Some mods work fully clientside, and some require everybody to have it installed.
 

--- a/docs/modding/initial-setup.md
+++ b/docs/modding/initial-setup.md
@@ -15,7 +15,7 @@ This section of the wiki will cover how to get set up for development.
 
 Once you're set up, make sure to check the [Modding APIs](/apis/modding-apis) section to see if there's any libraries that would make creating your mod easier.
 
-## Setting up your development environment
+## Setting up your development environment {#setup-env}
 
 Before you can start modding, you'll need some tools to actually create mods. Luckily, all of these are **available for free**. 
 
@@ -23,7 +23,7 @@ Before you can start modding, you'll need some tools to actually create mods. Lu
 This guide is roughly based on some parts of the [BepInEx setup guide](https://docs.bepinex.dev/articles/dev_guide/plugin_tutorial/1_setup.html), which is another great resource for learning how to mod
 :::
 
-### .Net SDK
+### .Net SDK {#dotnet-sdk}
 An SDK (=Software Development Kit) is a system that allows you to turn your code into something that your PC can run. It is used by other tools, and you'll generally not interact with it directly.
 
 You'll want to download and install the latest .Net 7 SDK version from [this page](https://dotnet.microsoft.com/en-us/download/dotnet/7.0). It'll look something like this:
@@ -68,7 +68,7 @@ Enabled = false // [!code --]
 Enabled = true // [!code ++]
 ```
 
-### Decompiler (*highly recommended / near essential*)
+### Decompiler (*highly recommended / near essential*) {#decompiler}
 A decompiler allows you to decompile an existing program. This is technical terminology that can roughly be translated to "it allows you to peek behind the curtain and see what the code of a program looks like". Why is this important, you may ask? Well, if we're going to mod a game, we first need to know *what* to mod. Do we want to reduce the price of items? We'll need to know in what part of the code items are displayed and sold to the player. Do we want to add a weather condition? We'll need to know in what parts of the code the game handles and spawns weather.
 
 We recommend one (or all) of three free options:
@@ -80,17 +80,17 @@ We recommend one (or all) of three free options:
 **Note you do not necessarily need this if you have Rider or Visual Studio, since they come with built-in decompilers. Note that different decompilers offer slightly different results, and have different interfaces.**
 :::
 
-### Unity Explorer (optional)
+### Unity Explorer (optional) {#unity-explorer}
 [Unity Explorer](https://github.com/sinai-dev/UnityExplorer) is a tool which adds an in-game UI that allows you to explore, debug, and modify the game while it's running. This tool can be highly useful to get to know the game's technical side better, and his hence strongly recommended.
 
 You will want to download the version compatible with the latest version of BepInEx (5).
 
 [![Unity Explorer download](/images/initial-setup/unityexplorerdownload.png)](https://github.com/sinai-dev/UnityExplorer/releases/latest/download/UnityExplorer.BepInEx5.Mono.zip)
 
-### Additional tools (optional)
+### Additional tools (optional) {#other-tools}
 There are a number of BepInEx plugins and tools that might be useful as you get more experienced with modding. The BepInEx devs have helpfully listed them [here](https://docs.bepinex.dev/articles/dev_guide/dev_tools.html).
 
-## Creating a GitHub account
+## Creating a GitHub account {#create-github-account}
 
 We strongly recommend using git - a "version control system". The most popular website that offers this as a (free) service is [GitHub](https://github.com/).
 

--- a/docs/modding/starting-a-mod.md
+++ b/docs/modding/starting-a-mod.md
@@ -4,18 +4,18 @@ description: Learn how to create a basic project for a Lethal Company mod.
 
 # Starting a mod
 
-## Setting up your project
+## Setting up your project {#setup-project}
 ::: warning
 This guide assumes you've completed all the required steps in **[initial setup](initial-setup)**, or that you know what you're doing.
 :::
 
 This guide follows certain parts of the [official BepInEx guide](https://docs.bepinex.dev/articles/dev_guide/plugin_tutorial/2_plugin_start.html).
 
-### Using the template repository
+### Using the template repository {#using-template-repo}
 
 We have created a [template repository](https://github.com/LethalCompany/LethalCompanyTemplate) on GitHub. If you're remotely familiar with GitHub, or willing to [learn](initial-setup.html#creating-a-github-account), this might serve as a quick start. It does come with some minor drawbacks such as it using "LethalCompanyTemplate" as project name in a number of files, but you can edit this. It should build out-of-the-box with no edits required; though you may need to add BepInEx as a NuGet source (see the [relevant](#adding-nuget-source) section below).
 
-### Creating your project
+### Creating your project {#create-project}
 
 First things first, you'll need to create your project. If you've not done so already, we recommend running the following command in a console to add some BepInEx templates for new projects:
 
@@ -25,11 +25,11 @@ dotnet new -i BepInEx.Templates --nuget-source https://nuget.bepinex.dev/v3/inde
 
 Next, you'll want to create a new project (sometimes called "solution", in CSharp). There are two main ways to do this.
 
-#### Using an IDE (more control)
+#### Using an IDE (more control) {#using-ide}
 
 Depending on your IDE, this process will look slightly different. You'll want to give the solution the name of your soon-to-be mod. If given the option to use a template (you may want to google for *"how to use template in Visual Studio"* or *"how to use template in Rider"*), use the `BepInEx 5 Plugin Template`.
 
-#### Using the console (simpler)
+#### Using the console (simpler) {#using-console}
 
 Alternatively, you can open a console and run the following command, assuming you've set up the templates using the command above. Replace `MyFirstPlugin` with your mod's name:
 
@@ -46,11 +46,11 @@ Details: Object reference not set to an instance of an object.`
 If you get this error, try downgrading to the [.NET 7 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
 :::
 
-### Organising your modding projects
+### Organising your modding projects {#organize-project}
 
 We recommend creating a folder somewhere easily accessible that will store all of your future modding projects. Something like "LethalCompanyMods". Move the newly created folder for your mod into this folder, to keep things well-organised.
 
-### Adding NuGet source
+### Adding NuGet source {#add-nuget}
 
 BepInEx uses a separate NuGet source. You'll need to add the BepInEx NuGet source to your global source list.
 
@@ -102,7 +102,7 @@ This should result in a complete file resembling the following:
 
 :::
 
-### Making sure your mod is set up correctly
+### Making sure your mod is set up correctly {#check-mod-setup}
 
 Mods are developed for specific versions of Unity and .NET, which can be specified in a configuration file. This file is a `.csproj` file, and has as name the name of your mod (e.g. `MyFirstPlugin.csproj`). If you used the console command correctly, it should work out of the box. However, you'll want to double check this to prevent any easy-to-fix problems that can result from not having it set up correctly. When using an IDE, the template might not use the correct version, so in this case you'll definitely have to check things.
 


### PR DESCRIPTION
With some of the longer headers/headings, it can create long or illegible anchors in the url (see examples). Used VitePress' custom anchors feature to shorten longer ones or ones with symbols.

Examples
`/extras/faq#does-x-mod-require-everybody-to-have-it-installed` => `/extras/faq#require-all-to-install`

`/modding/initial-setup#decompiler-highly-recommended-near-essential` => `/modding/initial-setup#decompiler`

`/advanced-modding/networking#c-events` => `/advanced-modding/networking#csharp-events`

For future reference, this can be done by doing the following:
```md
## Really long example header that would create an enormous anchor
<!-- => -->
## Really long example header that would create an enormous anchor {#example-header}
```
