### PR TITLE
Template has wrong version of UnityEngine.Modules, Added a warning note that tells users how to fix the issue.

### DIFF
--- a/docs/dev/starting-a-mod.md
+++ b/docs/dev/starting-a-mod.md
@@ -40,6 +40,11 @@ dotnet new bepinex5plugin -n MyFirstPlugin -T "netstandard2.1" -U "2022.3.9"
 ```
 
 ::: warning
+If you get the following error (or simmilar) later then double check your `UnityEngine.Modules` Reference's Version is `2022.3.9` and NOT `5.6.0`.
+If this is confusing we recommend using out [template repository](https://github.com/LethalCompany/LethalCompanyTemplate).
+:::
+
+::: warning
 Some people have been [reporting problems](https://github.com/BepInEx/BepInEx.Templates/issues/8) creating new BepInEx plugins from the template when using the .NET 8 SDK:
 
 `Failed to create template.


### PR DESCRIPTION
Issue with the BepInEx Template causing the wrong version of UnityEngine.Modules from being added. This can/has caused a good bit of confusion with error messages. This change adds a note about this issue and how to fix it.