### PR TITLE
Update References to UnityNetcodePatcher; Update Beginner Guide Sidebar

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,7 +50,8 @@ export default defineConfig({
               text: 'Other Resources',
               items: [
                 {text: 'Frequently Asked Questions', link: '/extras/faq'},
-                {text: 'Contributing Translations', link: '/translation/translating-the-wiki'},
+                { text: 'Contributing Translations', link: '/contribute/translating-the-wiki' },
+                { text: 'Contributing Articles', link: '/contribute/writing-articles' },
                 {text: 'About', link: '/extras/about'}
               ]
             },

--- a/docs/dev/advanced/networking.md
+++ b/docs/dev/advanced/networking.md
@@ -1,7 +1,7 @@
 ---
 prev: false
 next: false
-description: An advanced overview of how to use UnityNetcodeWeaver to add networking to your Lethal Company mods.
+description: An advanced overview of how to use Unity Netcode Patcher to add networking to your Lethal Company mods.
 ---
 
 # Networking
@@ -16,11 +16,11 @@ This is not a tutorial on how to use Unity's [Netcode for GameObjects](https://d
 
 ## Preface
 
-This tutorial requires using [@EvaisaDev](https://github.com/EvaisaDev/)'s [UnityNetcodeWeaver](https://github.com/EvaisaDev/UnityNetcodeWeaver) (Thank you very much Evaisa!). This tutorial will only go into the basics of using this tool; if you run into any issues, ask in the [NetcodePatcher Forum Post](https://discord.com/channels/1169792572382773318/1175504315029389343) on the [Unofficial Lethal Company Community Discord](https://discord.gg/nYcQFEpXfU).
+This tutorial requires using [@EvaisaDev](https://github.com/EvaisaDev/)'s [Unity Netcode Patcher](https://github.com/EvaisaDev/UnityNetcodePatcher) (Thank you very much Evaisa!). This tutorial will only go into the basics of using this tool; if you run into any issues, ask in the [NetcodePatcher Forum Post](https://discord.com/channels/1169792572382773318/1175504315029389343) on the [Unofficial Lethal Company Community Discord](https://discord.gg/nYcQFEpXfU).
 
-### Why use Unity Netcode Weaver? {#why-netcode-weaver}
+### Why use Unity Netcode Patcher? {#why-netcode-patcher}
 
-Unity Netcode Weaver replicates the IL Post Processing Unity performs when compiling code utilizing Netcode for GameObjects package. This turns the C# code before the post processing step:
+Unity Netcode Patcher replicates the IL Post Processing Unity performs when compiling code utilizing Netcode for GameObjects package. This turns the C# code before the post processing step:
 
 ```cs
 [ClientRpc]
@@ -425,16 +425,16 @@ When subscribing and unsubscribing to an event, make sure that <i>both</i> the h
 Hooking to a ClientRpc can cause errors with code running multiple times on the host instance. Avoid hooking to any ClientRpcs - and if you must, consider adding a debounce.
 :::
 
-## Using Unity Netcode Weaver {#using-netcode-weaver}
+## Using Unity Netcode Patcher {#using-netcode-patcher}
 
-Now that we've finished the networking code, all that's left is to patch the compiled mod assembly with Unity Netcode Weaver/Patcher. Before we can do so, we need to prepare the mod for patching. 
+Now that we've finished the networking code, all that's left is to patch the compiled mod assembly with Unity Netcode Patcher. Before we can do so, we need to prepare the mod for patching. 
 
 1. Make sure that there is a .pdb file when you build your plugin. If it is not there, make sure that Debug Symbols is set to `Portable` and not embedded.
 
 2. Add the following code to your main Plugin.cs file, and make sure the method only runs **once**:
 
 ```cs
-private static void NetcodeWeaver()
+private static void NetcodePatcher()
 {
     var types = Assembly.GetExecutingAssembly().GetTypes();
     foreach (var type in types)
@@ -453,11 +453,11 @@ private static void NetcodeWeaver()
 
 static void Awake()
 {
-    NetcodeWeaver(); // ONLY RUN ONCE // [!code warning]
+    NetcodePatcher(); // ONLY RUN ONCE // [!code warning]
 }
 ```
 
-Before you can run Unity Netcode Weaver, make sure it's set up - specifically, copy the contents of `Lethal Company/Lethal Company_Data/Managed` into `NetcodePatcher/deps`.
+Before you can run Unity Netcode Patcher, make sure it's set up - specifically, copy the contents of `Lethal Company/Lethal Company_Data/Managed` into `NetcodePatcher/deps`.
 
 Now, you just have to add the following Post-Build Event to your project:
 
@@ -466,9 +466,9 @@ cd <NetcodePatcher Folder Directory Here>
 NetcodePatcher.dll $(TargetDir) deps/
 ```
 
-If this does not work, you can [follow the instructions on how to use UnityNetcodeWeaver from the command line.](https://github.com/EvaisaDev/UnityNetcodeWeaver#usage-from-command-line)
+If this does not work, you can [follow the instructions on how to use Unity Netcode Patcher from the command line.](https://github.com/EvaisaDev/UnityNetcodePatcher#usage-from-command-line)
 
 ## Conclusion
 
-Now that you've finally finished all the code and patched it with UnityNetcodeWeaver, you should have networking in your mod! Congrats! Pat yourself on the back! It's not easy getting to this stage, and you will always run into issues as you continue your modding journey. But don't fret! You can always get help in the [Unofficial Lethal Company Community Discord!](https://discord.gg/nYcQFEpXfU)
+Now that you've finally finished all the code and patched it with Unity Netcode Patcher, you should have networking in your mod! Congrats! Pat yourself on the back! It's not easy getting to this stage, and you will always run into issues as you continue your modding journey. But don't fret! You can always get help in the [Unofficial Lethal Company Community Discord!](https://discord.gg/nYcQFEpXfU)
 

--- a/docs/dev/intermediate/custom-config-syncing.md
+++ b/docs/dev/intermediate/custom-config-syncing.md
@@ -17,7 +17,7 @@ There are many different ways you could achieve this, but we will only go throug
 
 ## Manually Syncing Instances
 For this approach, we will take advantage of [Custom Messages](https://docs-multiplayer.unity3d.com/netcode/current/advanced-topics/message-system/custom-messages/#named-messages), specifically Named Messages.
-They are unbound to any GameObject, meaning **NetcodeWeaver** and **NetworkBehaviour** are **NOT necessary**.
+They are unbound to any GameObject, meaning **Unity Netcode Patcher** and **NetworkBehaviours** are **NOT necessary**.
 
 ::: info
 Before you proceed, it is recommended you familiarize yourself with [Custom configs](/dev/intermediate/custom-configs).

--- a/docs/extras/about.md
+++ b/docs/extras/about.md
@@ -16,7 +16,7 @@ This guide is mainly written by [Max](https://github.com/MaxWasUnavailable) & [B
 ### Developer / Tool Credits
 
 - **BepInEx Contributors** for [BepInEx](https://github.com/BepInEx/BepInEx).
-- **EvaisaDev** for [UnityNetcodeWeaver](https://github.com/EvaisaDev/UnityNetcodeWeaver).
+- **EvaisaDev** for [Unity Netcode Patcher](https://github.com/EvaisaDev/UnityNetcodePatcher).
 
 Thank you to [everyone else](https://github.com/LethalCompany/ModdingWiki/graphs/contributors) that contributed to the guide on GitHub.
 


### PR DESCRIPTION
EvaisaDev's `UnityNetcodeWeaver` repo was renamed to `UnityNetcodePatcher`. Although the link will now redirect to the correct repo, I still want to update all the references to the library to be correct.

Also fixed another dead link (in the Beginner's Guide Sidebar) :)