### PR TITLE
Add instructions for workaround for using on MicroSD card.

### DIFF
--- a/docs/installation/installing-r2modman-linux.md
+++ b/docs/installation/installing-r2modman-linux.md
@@ -12,7 +12,7 @@ This guide will run you through installing and using [r2modman](https://github.c
 ## Steam Deck Specific Preparation
 On Steam Deck you will need to do the following before you can follow this guide:
 
- - Make sure the game is installed into the internal storage - mods will not load if the game is installed to the MicroSD card.
+ - If the game is installed to the MicroSD card instead of internal storage, you will need to use a workaround. Open a split view in your file manager, and navigate to /home/deck/.steam/steam/steamapps/compatdata/ and go to where your steamapps folder is located on your MicroSD card. Create a folder named compatdata, then drag the 1966720 folder to your new compatdata folder. Select "Link Here", and you're done.
  - Enter **Desktop Mode** by holding down the power button and selecting Desktop Mode from the menu.
 
 Once you're at the desktop, you're ready to continue!


### PR DESCRIPTION
The wiki currently says that mods can't be used if the game is installed to the MicroSD card on Steam Deck. R2modman looks for the compatdata on your MicroSD card if the game is installed there, so if you just create a compatdata folder and link the Lethal Company compatdata folder there then mods will work.