### PR TITLE
Add Sidebar Differentiation b/w Clickable & Non-clickable Drop-downs

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -139,10 +139,10 @@
 
 .VPSidebarItem.has-active:not(.is-active) > .item > .text,
 .VPSidebarItem.has-active:not(.is-active) > .item > .link > .text {
-    color: rgb(0, 141, 125) !important;
+    color: rgb(37, 104, 97) !important;
 }
 
 .dark .VPSidebarItem.has-active:not(.is-active) > .item > .text,
 .dark .VPSidebarItem.has-active:not(.is-active) > .item > .link > .text {
-    color: rgba(185, 255, 245, .7) !important;
+    color: rgba(205, 235, 231, 0.7) !important;
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -134,7 +134,11 @@
  * -------------------------------------------------------------------------- */
 
 .VPSidebarItem:not(.is-link) > .item[role=button] > .text {
-    color: rgba(255, 205, 195, .7);
+    color: rgba(85, 165, 156, 1);
+}
+
+.dark .VPSidebarItem:not(.is-link) > .item[role=button] > .text {
+    color: rgba(185, 255, 245, .7);
 }
 
 .VPSidebarItem.has-active:not(.is-link) > .item[role=button] > .text {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -133,14 +133,16 @@
  * Component: Sidebar Category Divider (Non-Clickable)
  * -------------------------------------------------------------------------- */
 
-.VPSidebarItem:not(.is-link) > .item[role=button] > .text {
-    color: rgba(85, 165, 156, 1);
+.VPSidebarItem:not(.is-link.has-active) > .item[role=button] > .text {
+    color: var(--vp-c-text-1);
 }
 
-.dark .VPSidebarItem:not(.is-link) > .item[role=button] > .text {
-    color: rgba(185, 255, 245, .7);
+.VPSidebarItem.has-active:not(.is-active) > .item > .text,
+.VPSidebarItem.has-active:not(.is-active) > .item > .link > .text {
+    color: rgb(0, 141, 125) !important;
 }
 
-.VPSidebarItem.has-active:not(.is-link) > .item[role=button] > .text {
-    color: var(--vp-c-text-1) !important;
+.dark .VPSidebarItem.has-active:not(.is-active) > .item > .text,
+.dark .VPSidebarItem.has-active:not(.is-active) > .item > .link > .text {
+    color: rgba(185, 255, 245, .7) !important;
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -129,3 +129,14 @@
   --docsearch-primary-color: var(--vp-c-brand-1) !important;
 }
 
+/**
+ * Component: Sidebar Category Divider (Non-Clickable)
+ * -------------------------------------------------------------------------- */
+
+.VPSidebarItem:not(.is-link) > .item[role=button] > .text {
+    color: rgba(255, 205, 195, .7);
+}
+
+.VPSidebarItem.has-active:not(.is-link) > .item[role=button] > .text {
+    color: var(--vp-c-text-1) !important;
+}


### PR DESCRIPTION
It wasn't clear what drop-downs in the sidebar had content on it and what didn't, so this adds css to color the non-clickable/no-content headers/drop-downs. Both dark and light mode are supported.

Dark Mode:
![image](https://github.com/LethalCompany/ModdingWiki/assets/26671040/61c53b1b-016d-4490-97eb-e7008e0993ff)

Light Mode:
![image](https://github.com/LethalCompany/ModdingWiki/assets/26671040/16447169-d01b-45c7-b372-4ec778b82ea7)
